### PR TITLE
Add deploy and publish to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,3 +18,33 @@ jobs:
             - ./node_modules
       - run: npm run lint
       - run: npm test
+
+  deploy:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/project
+      - restore_cache:
+          keys:
+            - dependencies-{{ checksum "package-lock.json" }}
+      - run: npm install
+      - save_cache:
+          key: dependencies-{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
+      - run: npm publish
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
This PR adds publishing of the module to NPM from the master branch to the CircleCI config. The intention is to test this functionality in this project and add it to the others upon successful publishing.